### PR TITLE
Flash-53: add option to download ASCII files

### DIFF
--- a/django/flashdb/db_query/templates/ascii.html
+++ b/django/flashdb/db_query/templates/ascii.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>FLASHDB</title>
+    <style>
+        div {
+	    	border: 2px solid black;
+	    	padding: 4px;
+	}
+	div.slim {
+		border: 0;
+		padding: 0;
+	}
+	table, th, td {
+		border: 1px solid black;
+		border-collapse: collapse;
+		margin-left: auto;
+		margin-right: auto;
+	}
+	.fixed {
+		position:fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+	}
+
+
+    </style>
+</head>
+<body style="background-color:#ABB2B9;">
+	<div class="fixed" style="background-color:aquamarine;">
+	<H1 style="text-align: center;">FLASH Database Query Result</H1>
+	{% load static %}
+	<img src="{% static 'db_query/SKAO_ausSRC_logo_colour_white_bg.png' %}" alt="AusSRC" style="position:absolute; top:20px; right:30px;" width="200" height="100">
+	<img src="{% static 'db_query/flash.jpeg' %}" alt="FLASH" style="position:absolute; top:20px; left:30px;" width="180" height="100">
+	<p style="text-align: center;"> <strong><i>Query for SBID = {{ sbid }}</i></strong></p>
+	<p  style="text-align: left;"> <a href="{% static ascii_tar %}" download>Download</a> the source ASCII files in a tar archive</p>
+	<form action="/db_query/">
+                <input type="hidden" id="session_id" name="session_id" value={{ session_id }}/>
+		<input type="submit" value="Return to Main page"/>
+	</form>
+</body>
+</html>

--- a/django/flashdb/db_query/templates/index.html
+++ b/django/flashdb/db_query/templates/index.html
@@ -76,6 +76,8 @@
 		<label for="linefinder">Get linefinder outputs</label><br>
 		<input type="radio" id="source" name="query_type" value="SOURCE">
 		<label for="source">View and/or download plots for source</label><br>
+		<input type="radio" id="asciifiles" name="query_type" value="ASCII">
+		<label for="asciifiles">Download ASCII files</label><br>
 
 		<div id="dbQUERY" class="desc" style="display: none;">
 			<p>QUERY the database - this will display metadata on an sbid</p>
@@ -109,6 +111,7 @@
 			<input type="checkbox" id="reverse2" name="reverse2">Reverse sort order<br>
 			<input type="checkbox" id="inverted" name="inverted">Use results from inverted-spectra run, if available.
 		</div>
+		
 		<div id="dbSOURCE" class="desc" style="display: none;">
 			<p>Get plots for individual source, or <i>n</i> brightest sources - 
                             NOTE: Only sources with a min flux value > 30mJy are stored in the DB </p>
@@ -121,9 +124,15 @@
 			source_id <input type="text" id="comp" name="comp"> OR brightest 
 			<input type="text" id="bright" name="bright">sources<br>
 		</div>
+		
+		<div id="dbASCII" class="desc" style="display: none;">
+			<p>Download ASCII tarball for individual SBID</p>
+			<label for="sbid_for_ascii">Enter integer for SBID to query:</label><br>
+			<input type="text" id="sbid_for_ascii" name="sbid_for_ascii"><br>
+		</div>
 
-                <input type="hidden" id="session_id" name="session_id" value={{ session_id }}>
-		<input type="submit" id="submit" value="Submit" onClick="return empty()" /> <i>(The last two may take some time to process)</i>
+        <input type="hidden" id="session_id" name="session_id" value={{ session_id }}>
+		<input type="submit" id="submit" value="Submit" onClick="return empty()" /> <i>(The last three may take some time to process)</i>
 	</form>
 	</div>
 	<div class="dark-image">

--- a/django/flashdb/db_query/templates/source.html
+++ b/django/flashdb/db_query/templates/source.html
@@ -37,7 +37,7 @@
 	<p style="text-align: center;"> uploaded: <i>{{ metadata.2 }}</i>, in <i>{{ metadata.3 }}</i>, field: <i>{{ metadata.1 }}</i></p>
 	<p  style="text-align: center;"> Number of Components (sources): <strong>{{ num_sources }}</strong> </p>
 	{% if num_sources > 0 %}
-	    <p  style="text-align: left;"> <a href="{% static tarball %}" download>Download</a> the sources in a tar archive</p>
+	    <p  style="text-align: left;"> <a href="{% static tarball %}" download>Download</a> the source plots in a tar archive</p>
 	{% endif %}
 	<form action="/db_query/">
                 <input type="hidden" id="session_id" name="session_id" value={{ session_id }}/>

--- a/django/flashdb/db_query/views.py
+++ b/django/flashdb/db_query/views.py
@@ -4,10 +4,13 @@ import re
 import psycopg2
 import random
 import string
+import sys
+sys.path.append('../..')
 
 from django.shortcuts import render
 from django.http import HttpResponse
 from django.db import connection
+from database import db_download
 from .models import MyModel
 
 #######################################################################################
@@ -344,6 +347,7 @@ def index(request):
     try:
         os.system(f"sudo rm -R {static_dir}/plots/{session_id}")
         os.system(f"sudo rm -R {static_dir}/linefinder/{session_id}")
+        os.system(f"sudo rm -R {static_dir}/ascii/{session_id}")
     except:
         pass
 
@@ -552,10 +556,19 @@ def query_database(request):
             tarball = f"db_query/plots/{session_id}/{tarball_name}"
 
         return render(request, 'source.html', {'session_id': session_id, 'sbid': sbid_val, 'comp_id': comp, 'brightest':bright, 'sources': sources, 'num_sources': int(len(sources)), 'tarball': tarball,'render': view_or_tar, 'metadata': metadata})
+    elif query_type == "ASCII":
+        ascii_dir = os.path.abspath(f"db_query/static/db_query/ascii/{session_id}/")
+        os.system(f"mkdir -p {ascii_dir}")
+        sbid_val = request.POST.get('sbid_for_ascii')
+        with connection.cursor() as cur:
+            sid,version = get_max_sbid_version(cur,sbid_val)
+            conn = connect(password=password)
+            db_download.get_ascii_files_tarball(conn,cur,sid,sbid_val,ascii_dir,version)
+            conn.close()
+            ascii_tar = f"db_query/ascii/{session_id}/{sbid_val}_{version}.tar.gz"
 
-
-
-
+        return render(request, 'ascii.html', {'session_id': session_id, 'sbid': sbid_val, 'version': version, 'ascii_tar': ascii_tar})
+    
 def my_view(request):
     with connection.cursor() as cursor:
         cursor.execute("SELECT sbid_num,version,comment FROM SBID order by sbid_num,version;")


### PR DESCRIPTION
* Download ASCII file from the radio menu. Second page (ascii.html) should show the link to download the tar.
* Clean up the ascii directory for the session upon startup.
* Relabel "Download the sources" to "Download  the source plots" for the plot download. 