### PR TITLE
Strip whitespaces around source numbers, remove unnecessary install

### DIFF
--- a/django/flashdb/db_query/views.py
+++ b/django/flashdb/db_query/views.py
@@ -608,6 +608,9 @@ def query_database(request):
                 comps = []
                 comp_vals = comp.split(',')
                 for val in comp_vals:
+                    val = val.strip()
+                    if not val:
+                        continue
                     comp = f"spec_SB{sbid_val}_component_{val}.fits"
                     comps.append(comp)
             # The path to Django's static dir for plots

--- a/django/flashdb/flashdb/settings.py.example
+++ b/django/flashdb/flashdb/settings.py.example
@@ -37,8 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'db_query',
-    'bootstrap5'
+    'db_query'
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
This now works:
<img width="515" height="299" alt="Screenshot 2025-08-08 at 5 15 02 pm" src="https://github.com/user-attachments/assets/2c2a468b-a73e-4aad-a99d-483199c31b57" />
