### PR TITLE
FLASH-71 Refactor flashfinder for new modules

### DIFF
--- a/linefinder/model.py
+++ b/linefinder/model.py
@@ -318,7 +318,7 @@ class Model():
                 rest_z = shift_frame(x_fine,mean_z)
                 rest_vel = zTOvel(rest_z, 'relativistic')
                 rest_vel *= constants.LIGHT_SPEED
-                int_S = np.abs(integrate.simps(emi_fine, rest_vel))
+                int_S = np.abs(integrate.simpson(emi_fine, x=rest_vel))
                 width = int_S/peak_S
             if options.x_units == 'optvel':
                 peak_z *= constants.LIGHT_SPEED
@@ -362,7 +362,7 @@ class Model():
                 rest_z = shift_frame(x_fine, mean_z)
                 rest_vel = zTOvel(rest_z, 'relativistic')
                 rest_vel *= constants.LIGHT_SPEED
-                int_opd = np.abs(integrate.simps(opd_fine, rest_vel))
+                int_opd = np.abs(integrate.simpson(opd_fine, x=rest_vel))
                 width = int_opd/peak_opd
             if options.x_units == 'optvel':
                 peak_z *= constants.LIGHT_SPEED

--- a/linefinder/output.py
+++ b/linefinder/output.py
@@ -289,8 +289,7 @@ def get_separated_posterior(self):
                     tmp_samples = []
                     mode_count += 1
             else:
-                #tmp_samples.append([__float_from_str(x) for x in line.lower().split()])
-                tmp_samples.append([float(x) for x in line.lower().split()])
+                tmp_samples.append([__float_from_str(x) for x in line.lower().split()])
     f.close()
     tmp_samples = np.array(tmp_samples)
     if mode_count > 1:

--- a/pipeline/detection/slurm_run_flashfinder.sh
+++ b/pipeline/detection/slurm_run_flashfinder.sh
@@ -16,28 +16,14 @@ MODE=$5
 mkdir -p "$1"/logs
 cd "$1"
 
-module unload gcc-native/14.2
-module swap pawseyenv/2025.08 pawseyenv/2024.05
-module load gcc/12.2.0
-module load libfabric/1.15.2.0 
-
-module load python/3.11.6 
-module load py-matplotlib/3.8.1 
-module load py-astropy/5.1 
-module load py-mpi4py/3.1.5-py3.11.6 
-module load gcc/12.2.0 
-module load py-scipy/1.11.3 
-module load py-numpy/1.24.4 
-
-#module load python/3.11.6
-#module load py-numpy/1.25.2
-#module load py-scipy/1.14.1
-#module load py-matplotlib/3.9.2
-#module load py-astropy/5.1
-#module load py-mpi4py/3.1.5-py3.11.6
-
-#module load py-astropy/5.1
-#module load py-mpi4py/3.1.5-py3.11.6
+# Using pawseyenv/2025.08 (Setonix default) with gcc-native/14.2
+# Old module set (pawseyenv/2024.05 + gcc/12.2.0) removed — incompatible with scipy>=1.14
+module load python/3.11.6
+module load py-numpy/1.25.2
+module load py-scipy/1.14.1
+module load py-matplotlib/3.9.2
+module load py-astropy/5.1
+module load py-mpi4py/3.1.5-py3.11.6
 
 
 


### PR DESCRIPTION
Replaced the old module set (which required manually swapping to pawseyenv/2024.05 and loading gcc/12.2.0 and libfabric) with the new module set that works natively in the default pawseyenv/2025.08 environment. 

scipy.integrate.simps was deprecated in SciPy 1.11 and completely removed in SciPy 1.14. Replaced both calls with scipy.integrate.simpson, and updated the x axis argument to be passed as a keyword argument (x=rest_vel)

Activated the existing __float_from_str() helper function (which was already in the codebase but commented out) to handle Fortran scientific notation.