### PR TITLE
SOF-122: make sure summary table for line finder shows all components

### DIFF
--- a/django/flashdb/db_query/views.py
+++ b/django/flashdb/db_query/views.py
@@ -205,21 +205,18 @@ def get_results_for_sbid(cur,sbid,version,LN_MEAN,order,reverse,dir_download,inv
         f.write("#Component_name,comp_id,modenum,ra_hms_cont,dec_dms_cont,ra_deg_cont,dec_deg_cont,flux_peak,flux_int,x0_1_maxl,dx_1_maxl,y0_1_maxl,abs_peakz_median,abs_peakz_siglo,abs_peakz_sighi,abs_peakopd_median,abs_peakopd_siglo,abs_peakopd_sighi,abs_intopd_median(km/s),abs_intopd_siglo(km/s),abs_intopd_sighi(km/s),abs_width_median(km/s),abs_width_siglo(km/s),abs_width_sighi(km/s),ln(B)_mean,ln(B)_sigma,chisq_mean,chisq_sigma,field\n")
     #print()
     outputs = []
-    alt_outputs = []
     for result in results:
         comp_id = "component" + result[1].split("_component")[1].split(".")[0]
-        if verbose:
-            comp= "component" + result[1].split("_component")[1].split(".")[0]
-            linefinder_data = results_dict[comp]
-            for line in linefinder_data:
-                vals = line.split()
-                if float(vals[17]) > ln_mean:
-                    f.write(f"{result[0]},{comp},{vals[1]},{result[2]},{result[3]},{result[4]},{result[5]},{result[6]},{result[7]},{vals[2]},{vals[3]},{vals[4]},{vals[5]},{vals[6]},{vals[7]},{vals[8]},{vals[9]},{vals[10]},{vals[11]},{vals[12]},{vals[13]},{vals[14]},{vals[15]},{vals[16]},{vals[17]},{vals[18]},{vals[19]},{vals[20]},{pointing}\n")
-                alt_outputs.append([result[0],comp_id,result[4],result[5],vals[5],vals[8],vals[11],vals[14],result[9],result[10],pointing])
-        outputs.append([result[0],comp_id,result[2],result[3],result[4],result[5],result[9],result[10],pointing])
+        linefinder_data = results_dict[comp_id]
+        for line in linefinder_data:
+            vals = line.split()
+            if float(vals[17]) > ln_mean:
+                if verbose:
+                    f.write(f"{result[0]},{comp_id},{vals[1]},{result[2]},{result[3]},{result[4]},{result[5]},{result[6]},{result[7]},{vals[2]},{vals[3]},{vals[4]},{vals[5]},{vals[6]},{vals[7]},{vals[8]},{vals[9]},{vals[10]},{vals[11]},{vals[12]},{vals[13]},{vals[14]},{vals[15]},{vals[16]},{vals[17]},{vals[18]},{vals[19]},{vals[20]},{pointing}\n")
+                outputs.append([result[0],comp_id,result[2],result[3],result[4],result[5],vals[1],vals[17],pointing])
     if verbose:
         f.close()
-    return outputs,alt_outputs
+    return outputs
 
 ##################################################################################################
 def get_ascii_files_tarball(conn, cur, sid, sbid, static_dir, version, password=None):
@@ -684,7 +681,7 @@ def query_database(request):
             static_dir.mkdir(parents=True, exist_ok=True)
             version = None
             # Screen outputs:
-            outputs,alt_outputs = get_results_for_sbid(cursor,sbid_val,version,lmean,order,reverse,static_dir,inverted,masked)
+            outputs = get_results_for_sbid(cursor,sbid_val,version,lmean,order,reverse,static_dir,inverted,masked)
         # Full tarball of results - here we need to open a psycopg2 connection to access the lob:
         if outputs:
             conn = connect(password=password)
@@ -699,7 +696,7 @@ def query_database(request):
             else:
                 csv_file = f"db_query/linefinder/{session_id}/{sbid_val}_linefinder_outputs.csv"
             return render(request, 'linefinder.html', {'session_id': session_id, 'sbid': sbid_val, 'lmean': lmean,\
-                'outputs': outputs, 'csv_file': csv_file, 'alt_outputs': alt_outputs, 'num_outs': len(outputs), \
+                'outputs': outputs, 'csv_file': csv_file, 'num_outs': len(outputs), \
                 'tarball': tarball, 'inverted':inverted, 'masked':masked})
         else:
             return HttpResponse(f"No Linefinder results for sbid {sbid_val}")


### PR DESCRIPTION
1. alt_outputs is not used -> removed.
2. comp is duplicate of comp_id -> removed.
3. Make sure summary table shows all components and each shows its modenum and lmean. 
4. if float(vals[17]) > ln_mean -> This is applying ln_mean filter. It should also be applied for summary table, as for full table.